### PR TITLE
Fixed type error

### DIFF
--- a/index.js
+++ b/index.js
@@ -471,7 +471,7 @@ Table.prototype.copyValueGeneric = function(s, sO, t, tO) {
     }
     while (size--) t[tO++] = s[sO++];
   } else {
-    s.copy(t, tO, sO, sO + size);
+    this.copy(t, tO, sO, sO + size);
   }
 };
 


### PR DESCRIPTION
Running your example code, I got the following error:

`TypeError: s.copy is not a function`

it seems a typo. Fixed it, now it works well!